### PR TITLE
updated location of nltk data download

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -84,6 +84,7 @@ RUN curl https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.
 COPY backend/requirements.txt /workspace/backend/requirements.txt
 WORKDIR /workspace/backend
 RUN python3 -m pip install -r requirements.txt
+RUN python3 -m pip nltk.downloader popular
 
 # Expose server ports
 EXPOSE 1560 1561 1562

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ FROM python:3.11
 RUN python3 -m pip install --upgrade pip
 COPY ./backend/requirements.txt /workspace/backend/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /workspace/backend/requirements.txt
+RUN python3 -m pip nltk.downloader popular
 COPY --from=build /workspace/static /workspace/static
 COPY ./backend /workspace/backend
 WORKDIR /workspace

--- a/backend/services/generator.py
+++ b/backend/services/generator.py
@@ -2,7 +2,7 @@ from ..models import Challenge, meChallenge, weChallenge
 from urllib.request import urlopen
 import random
 import nltk
-nltk.download('popular')
+# nltk.download('popular')
 
 word_site = "https://www.mit.edu/~ecprice/wordlist.10000"
 


### PR DESCRIPTION
nltk.download() line no longer needed in generator.py

nltk data is downloaded when docker is constructed, hopefully this change works for production. 

i will be bypassing review in order to fix deployment ASAP